### PR TITLE
Add TypeScript chat app example

### DIFF
--- a/my-chat-app/README.md
+++ b/my-chat-app/README.md
@@ -1,0 +1,24 @@
+# My Chat App
+
+This is a minimal React + TypeScript chat example built with Vite. It uses **Tailwind CSS** for styling and **shadcn/ui** for UI components.
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+## Project Structure
+
+- `src/App.tsx` – wraps the chat in `ChatProvider` and renders `ChatWindow`.
+- `src/context/ChatContext.tsx` – global chat state using React Context.
+- `src/components/ChatWindow.tsx` – card containing messages and input.
+- `src/components/MessageList.tsx` – scrollable list of messages.
+- `src/components/MessageBubble.tsx` – styled message bubble.
+- `src/components/ChatInput.tsx` – input field and send button.
+
+Tailwind and shadcn/ui are configured through `tailwind.config.ts` and imported in `index.css`.
+
+Each chat message has a unique ID generated with the `uuid` package.
+

--- a/my-chat-app/index.html
+++ b/my-chat-app/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My Chat App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+

--- a/my-chat-app/package.json
+++ b/my-chat-app/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "my-chat-app",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "shadcn-ui": "^0.3.2",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^4.1.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.1.3",
+    "vite": "^4.5.0"
+  }
+}

--- a/my-chat-app/postcss.config.cjs
+++ b/my-chat-app/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/my-chat-app/src/App.tsx
+++ b/my-chat-app/src/App.tsx
@@ -1,0 +1,12 @@
+import ChatWindow from './components/ChatWindow';
+import { ChatProvider } from './context/ChatContext';
+
+export default function App() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <ChatProvider>
+        <ChatWindow />
+      </ChatProvider>
+    </div>
+  );
+}

--- a/my-chat-app/src/components/ChatInput.tsx
+++ b/my-chat-app/src/components/ChatInput.tsx
@@ -1,0 +1,22 @@
+import { Input, Button } from 'shadcn-ui';
+import { useChat } from '../context/ChatContext';
+
+export default function ChatInput() {
+  const { input, setInput, sendMessage } = useChat();
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') sendMessage();
+  };
+
+  return (
+    <div className="p-4 flex space-x-2 border-t">
+      <Input
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Type a message"
+      />
+      <Button onClick={sendMessage}>Send</Button>
+    </div>
+  );
+}

--- a/my-chat-app/src/components/ChatWindow.tsx
+++ b/my-chat-app/src/components/ChatWindow.tsx
@@ -1,0 +1,12 @@
+import { Card } from 'shadcn-ui';
+import MessageList from './MessageList';
+import ChatInput from './ChatInput';
+
+export default function ChatWindow() {
+  return (
+    <Card className="w-full max-w-md h-[500px] flex flex-col">
+      <MessageList />
+      <ChatInput />
+    </Card>
+  );
+}

--- a/my-chat-app/src/components/MessageBubble.tsx
+++ b/my-chat-app/src/components/MessageBubble.tsx
@@ -1,0 +1,19 @@
+import { Message } from '../context/ChatContext';
+
+interface Props {
+  message: Message;
+}
+
+export default function MessageBubble({ message }: Props) {
+  const isUser = message.sender === 'user';
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>\
+      <div
+        className={`rounded-lg px-3 py-2 shadow transition-all max-w-xs text-sm \
+          ${isUser ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-900'}`}
+      >
+        {message.text}
+      </div>
+    </div>
+  );
+}

--- a/my-chat-app/src/components/MessageList.tsx
+++ b/my-chat-app/src/components/MessageList.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+import { ScrollArea } from 'shadcn-ui';
+import { useChat } from '../context/ChatContext';
+import MessageBubble from './MessageBubble';
+
+export default function MessageList() {
+  const { messages, typing } = useChat();
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, typing]);
+
+  return (
+    <ScrollArea className="flex-1 space-y-2 p-4">
+      {messages.map(m => (
+        <MessageBubble key={m.id} message={m} />
+      ))}
+      {typing && <div className="text-sm text-gray-500">Bot is typing...</div>}
+      <div ref={endRef} />
+    </ScrollArea>
+  );
+}

--- a/my-chat-app/src/context/ChatContext.tsx
+++ b/my-chat-app/src/context/ChatContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { v4 as uuid } from 'uuid';
+
+export type Message = {
+  id: string;
+  sender: 'user' | 'bot';
+  text: string;
+};
+
+type ChatContextType = {
+  messages: Message[];
+  input: string;
+  typing: boolean;
+  setInput: (value: string) => void;
+  sendMessage: () => void;
+};
+
+const ChatContext = createContext<ChatContextType | undefined>(undefined);
+
+export function useChat() {
+  const ctx = useContext(ChatContext);
+  if (!ctx) throw new Error('useChat must be used within ChatProvider');
+  return ctx;
+}
+
+interface Props {
+  children: ReactNode;
+}
+
+export function ChatProvider({ children }: Props) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [typing, setTyping] = useState(false);
+
+  const sendMessage = () => {
+    if (!input.trim()) return;
+    const userMsg: Message = { id: uuid(), sender: 'user', text: input.trim() };
+    setMessages(prev => [...prev, userMsg]);
+    setInput('');
+    setTyping(true);
+    setTimeout(() => {
+      const botMsg: Message = { id: uuid(), sender: 'bot', text: 'This is a bot response.' };
+      setMessages(prev => [...prev, botMsg]);
+      setTyping(false);
+    }, 1000);
+  };
+
+  return (
+    <ChatContext.Provider value={{ messages, input, typing, setInput, sendMessage }}>
+      {children}
+    </ChatContext.Provider>
+  );
+}

--- a/my-chat-app/src/index.css
+++ b/my-chat-app/src/index.css
@@ -1,0 +1,4 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+

--- a/my-chat-app/src/main.tsx
+++ b/my-chat-app/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+

--- a/my-chat-app/tailwind.config.ts
+++ b/my-chat-app/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss'
+
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config

--- a/my-chat-app/tsconfig.json
+++ b/my-chat-app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{"path": "./tsconfig.node.json"}]
+}

--- a/my-chat-app/tsconfig.node.json
+++ b/my-chat-app/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Vite/React/TypeScript project with Tailwind and shadcn/ui
- implement a simple chat UI with message input and mock bot reply
- refactor with React Context and modular components

## Testing
- `npm run lint` *(fails: Cannot find module typings)*

------
https://chatgpt.com/codex/tasks/task_e_6843ae7be064832d85d3b58eac387a22